### PR TITLE
Add deprecation warning to meal prep assistant

### DIFF
--- a/meal-prep-assistant.py
+++ b/meal-prep-assistant.py
@@ -161,6 +161,7 @@ st.set_page_config(
     page_icon="👨‍🍳"  # You can use an emoji or a file path to an image
 )
 st.title("Meal prep assistant")
+st.warning("⚠️ **DEPRECATION NOTICE**: This product has been deprecated and is no longer actively maintained. Please consider migrating to alternative solutions.")
 st.write("Ask me questions such as 'What is the meal plan for this week?' or 'What \
 are the rally instructions for today?''")
 


### PR DESCRIPTION
Display prominent warning message at the top of the Streamlit interface to inform users that the product has been deprecated and is no longer actively maintained.

🤖 Generated with [Claude Code](https://claude.ai/code)